### PR TITLE
Prep release of 1.0.6

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ParallelStream.Mixfile do
   def project do
     [
         app: :parallel_stream,
-        version: "1.0.5",
+        version: "1.0.6",
         elixir: "~> 1.1",
         deps: deps(),
         package: package(),


### PR DESCRIPTION
@beatrichartz I saw your comment in #5 to prep a PR for release. This is meant to release the fix merged in from #4 that resolves several Elixir 1.4+ warnings.