### PR TITLE
Update Travis with new Elixir versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: elixir
 elixir:
   - 1.1.1
   - 1.2.6
-  - 1.3
+  - 1.3.4
+  - 1.4.5
+  - 1.5.1
 otp_release:
   - 17.5
   - 18.3


### PR DESCRIPTION
Updates Travis to now test against latest releases of 1.3.x, 1.4.x and 1.5.x.