### PR TITLE
fix(deps): Fix deprecations when compiling

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule ParallelStream.Mixfile do
         source_url: "https://github.com/beatrichartz/parallel_stream",
         description: "Parallel stream operations for Elixir",
         test_coverage: [tool: ExCoveralls],
-        preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test]
+        preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test]
     ]
   end
 
@@ -29,10 +29,10 @@ defmodule ParallelStream.Mixfile do
   defp deps do
     [
       {:excoveralls, "~> 0.5", only: :test},
-      {:ex_doc, only: :docs},
-      {:inch_ex, only: :docs},
-      {:earmark, only: :docs},
-      {:benchfella, only: :bench}
+      {:ex_doc, ">= 0.0.0", only: :docs},
+      {:inch_ex, ">= 0.0.0", only: :docs},
+      {:earmark, ">= 0.0.0", only: :docs},
+      {:benchfella, ">= 0.0.0", only: :bench}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
-%{"benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], [], "hexpm"},
+%{
+  "benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], [], "hexpm"},
   "cesso": {:hex, :cesso, "0.1.3"},
   "csvlixir": {:hex, :csvlixir, "2.0.2"},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
   "ex_csv": {:hex, :ex_csv, "0.1.3"},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.5.5", "d97b6fc7aa59c5f04f2fa7ec40fc0b7555ceea2a5f7e7c442aad98ddd7f79002", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
@@ -15,4 +16,5 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], [], "hexpm"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+}


### PR DESCRIPTION
Resolves:
```
ex_doc is missing its version requirement, use ">= 0.0.0" if it should match any version
inch_ex is missing its version requirement, use ">= 0.0.0" if it should match any version
earmark is missing its version requirement, use ">= 0.0.0" if it should match any version
benchfella is missing its version requirement, use ">= 0.0.0" if it should match any version
```

and

```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
  mix.exs:17
```

Thank you for this repo:)