### PR TITLE
slight improvements

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /doc
 erl_crash.dump
 *.ez
+.elixir_ls

--- a/bench/stream_bench.exs
+++ b/bench/stream_bench.exs
@@ -1,6 +1,7 @@
-defmodule Bench do
+defmodule StreamBench do
   use Benchfella
-  Benchfella.start
+
+  @times 1000
 
   setup_all do
     us = average_test_func_call_time
@@ -14,13 +15,13 @@ defmodule Bench do
   end
 
   bench "stream" do
-    1..10000
+    1..@times
     |> Stream.map(&test_func/1)
     |> Stream.run
   end
 
   bench "parallel_stream" do
-    1..10000
+    1..@times
     |> ParallelStream.map(&test_func/1)
     |> Stream.run
   end
@@ -33,9 +34,9 @@ defmodule Bench do
   end
 
   defp average_test_func_call_time do
-    (1..10000 |> Enum.reduce(0, fn _, acc ->
+    (1..@times |> Enum.reduce(0, fn _, acc ->
       { us, _ } = :timer.tc(&test_func/0)
       acc + us
-    end)) / 10000 |> Float.round(2)
+    end)) / @times |> Float.round(2)
   end
 end

--- a/lib/parallel_stream/producer.ex
+++ b/lib/parallel_stream/producer.ex
@@ -13,7 +13,7 @@ defmodule ParallelStream.Producer do
     chunk_size = worker_count * worker_work_ratio
 
     stream
-    |> Stream.chunk(chunk_size, chunk_size, [])
+    |> Stream.chunk_every(chunk_size, chunk_size, [])
     |> Stream.transform(
     fn ->
       {
@@ -25,7 +25,7 @@ defmodule ParallelStream.Producer do
       { inqueue, workers, outqueues, 0 }
     end,
     fn items, { inqueue, workers, outqueues, index } ->
-      mapped = items |> Stream.with_index |> Enum.map(fn { item, i } -> 
+      mapped = items |> Stream.with_index |> Enum.map(fn { item, i } ->
       outqueue = outqueues |> Enum.at(rem(i, worker_count))
       inqueue |> send({ index + i, item, outqueue })
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule ParallelStream.Mixfile do
       {:ex_doc, only: :docs},
       {:inch_ex, only: :docs},
       {:earmark, only: :docs},
-      {:benchfella, only: :bench}
+      {:benchfella, "~> 0.3.0", only: [:dev]},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
-%{"benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], [], "hexpm"},
+%{
+  "benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], [], "hexpm"},
   "cesso": {:hex, :cesso, "0.1.3"},
   "csvlixir": {:hex, :csvlixir, "2.0.2"},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
   "ex_csv": {:hex, :ex_csv, "0.1.3"},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.5.5", "d97b6fc7aa59c5f04f2fa7ec40fc0b7555ceea2a5f7e7c442aad98ddd7f79002", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
@@ -15,4 +16,5 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], [], "hexpm"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+}


### PR DESCRIPTION
- benchmark with benchfella works on Elixir 1.7
- removes a deprecation warning 
- adds `.formater.exs` to be run with `mix format` (not executed because it would touch every file) 