### PR TITLE
update producer.ex to remove compilation warning

### DIFF
--- a/lib/parallel_stream/producer.ex
+++ b/lib/parallel_stream/producer.ex
@@ -13,7 +13,7 @@ defmodule ParallelStream.Producer do
     chunk_size = worker_count * worker_work_ratio
 
     stream
-    |> Stream.chunk(chunk_size, chunk_size, [])
+    |> Stream.chunk_every(chunk_size, chunk_size, [])
     |> Stream.transform(
       fn ->
         {


### PR DESCRIPTION
warning: Stream.chunk/4 is deprecated. Use Stream.chunk_every/4 instead
  lib/parallel_stream/producer.ex:16: ParallelStream.Producer.build!/4