### PR TITLE
chore: replace deprecated func to fix warning

### DIFF
--- a/lib/parallel_stream/producer.ex
+++ b/lib/parallel_stream/producer.ex
@@ -13,7 +13,7 @@ defmodule ParallelStream.Producer do
     chunk_size = worker_count * worker_work_ratio
 
     stream
-    |> Stream.chunk(chunk_size, chunk_size, [])
+    |> Stream.chunk_every(chunk_size, chunk_size, [])
     |> Stream.transform(
       fn ->
         {


### PR DESCRIPTION
This is identical to the PR submitted by @kjinho, but perhaps the CI failure on that PR was a fluke and this one will pass?